### PR TITLE
Added border to buff icons for buffs that you are the caster of.  Cur…

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -21,18 +21,21 @@ local winFlag = bit32.bor(ImGuiWindowFlags.NoTitleBar, ImGuiWindowFlags.NoScroll
 local pulse = true
 local textureWidth = 20
 local textureHeight = 20
+local flashAlpha = 1
+local rise = true
 local ShowGUI = true
 local ver = 'v1.3'
-local tPlayerFlags = bit32.bor(ImGuiTableFlags.NoBorders,ImGuiTableFlags.NoBordersInBody, ImGuiTableFlags.NoPadInnerX, ImGuiTableFlags.NoPadOuterX,ImGuiTableFlags.Resizable,ImGuiTableFlags.SizingFixedFit)
+local tPlayerFlags = bit32.bor(ImGuiTableFlags.NoBorders, ImGuiTableFlags.NoBordersInBody, ImGuiTableFlags.NoPadInnerX,
+    ImGuiTableFlags.NoPadOuterX, ImGuiTableFlags.Resizable, ImGuiTableFlags.SizingFixedFit)
 local function GetInfoToolTip()
-   local pInfoToolTip = ( ME.DisplayName()..
-    '\t\tlvl: '..tostring(ME.Level())..
-    '\nClass: '..ME.Class.Name()..
-    '\nHealth: '..tostring(ME.CurrentHPs())..' of '..tostring(ME.MaxHPs())..
-    '\nMana: '..tostring(ME.CurrentMana())..' of '..tostring(ME.MaxMana())..
-    '\nEnd: '..tostring(ME.CurrentEndurance())..' of '..tostring(ME.MaxEndurance())
-)
-return pInfoToolTip
+    local pInfoToolTip = (ME.DisplayName() ..
+        '\t\tlvl: ' .. tostring(ME.Level()) ..
+        '\nClass: ' .. ME.Class.Name() ..
+        '\nHealth: ' .. tostring(ME.CurrentHPs()) .. ' of ' .. tostring(ME.MaxHPs()) ..
+        '\nMana: ' .. tostring(ME.CurrentMana()) .. ' of ' .. tostring(ME.MaxMana()) ..
+        '\nEnd: ' .. tostring(ME.CurrentEndurance()) .. ' of ' .. tostring(ME.MaxEndurance())
+    )
+    return pInfoToolTip
 end
 local combatStateActions = {
     COMBAT = function() DrawStatusIcon(1, 'In Combat') end,
@@ -49,7 +52,7 @@ local function getDuration(i)
     local h = math.floor(remaining / 3600) or 0
     remaining = remaining % 3600 -- remaining seconds after removing hours
     local m = math.floor(remaining / 60) or 0
-    local s = remaining % 60 -- remaining seconds after removing minutes
+    local s = remaining % 60     -- remaining seconds after removing minutes
     -- Format the time string as H : M : S
     local sRemaining = string.format("%02d:%02d:%02d", h, m, s)
     return sRemaining
@@ -64,29 +67,39 @@ end
 function DrawInspectableSpellIcon(iconID, spell, i)
     local cursor_x, cursor_y = ImGui.GetCursorPos()
     anim:SetTextureCell(iconID or 0)
-    ImGui.DrawTextureAnimation(anim, textureWidth, textureHeight)
+    if spell.Caster() == ME.DisplayName() then
+        ImGui.DrawTextureAnimation(anim, textureWidth, textureHeight, true)
+    else
+        ImGui.DrawTextureAnimation(anim, textureWidth, textureHeight)
+    end
     ImGui.SetCursorPos(cursor_x, cursor_y)
     ImGui.PushID(tostring(iconID) .. spell.Name() .. "_invis_btn")
+    if spell.Duration.TotalSeconds() < 18 and spell.Duration.TotalSeconds() > 0 then
+        local flashColor = IM_COL32(0, 0, 0, flashAlpha * 2)
+        ImGui.GetWindowDrawList():AddRectFilled(ImGui.GetCursorScreenPosVec() + 1,
+            ImGui.GetCursorScreenPosVec() + textureHeight, flashColor)
+    end
     ImGui.InvisibleButton(spell.Name(), ImVec2(textureWidth, textureHeight),
-    bit32.bor(ImGuiButtonFlags.MouseButtonRight))
+        bit32.bor(ImGuiButtonFlags.MouseButtonRight))
     if ImGui.IsItemHovered() then
         if (ImGui.IsMouseReleased(1)) then
             spell.Inspect()
             -- print(spell.Name()) -- DEBUG print name to make sure right click is working.
         end
         ImGui.BeginTooltip()
-        ImGui.Text(spell.Name()..'\n'..getDuration(i))
+        ImGui.Text(spell.Name() .. '\n' .. getDuration(i))
         ImGui.EndTooltip()
     end
     ImGui.PopID()
 end
+
 ---@param iconID integer
 ---@param spell MQSpell
 ---@param i integer
 function DrawStatusIcon(iconID, txt)
     local cursor_x, cursor_y = ImGui.GetCursorPos()
     anim:SetTextureCell(iconID or 0)
-    ImGui.DrawTextureAnimation(anim, textureWidth-5, textureHeight-5)
+    ImGui.DrawTextureAnimation(anim, textureWidth - 5, textureHeight - 5)
     if ImGui.IsItemHovered() then
         ImGui.BeginTooltip()
         ImGui.Text(txt)
@@ -97,31 +110,38 @@ end
 local function targetBuffs(count)
     -- Save the original item spacing
     local originalSpacingX, originalSpacingY = ImGui.GetStyle().ItemSpacing.x, ImGui.GetStyle().ItemSpacing.y
-    ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, 0, 0)
+    ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, 2, 2)
     -- Width and height of each texture
     local iconsDrawn = 0
     -- Calculate max icons per row based on the window width
     local windowWidth = ImGui.GetWindowContentRegionWidth()
     local maxIconsRow = (windowWidth) / (textureWidth)
+    if rise == true then
+        flashAlpha = flashAlpha + 1
+    elseif rise == false then
+        flashAlpha = flashAlpha - 1
+    end
+    if flashAlpha == 128 then rise = false end
+    if flashAlpha == 25 then rise = true end
     ImGui.BeginGroup()
-    if TARGET.BuffCount()~=nil then
-    for i = 1, count do
-        local sIcon = TARGET.Buff(i).SpellIcon() or 0
-        DrawInspectableSpellIcon(sIcon, TARGET.Buff(i), i)
-        iconsDrawn = iconsDrawn + 1
-        -- Check if we've reached the max icons for the row, if so reset counter and new line
-        if iconsDrawn >= maxIconsRow then
-            iconsDrawn = 0 -- Reset counter
+    if TARGET.BuffCount() ~= nil then
+        for i = 1, count do
+            local sIcon = TARGET.Buff(i).SpellIcon() or 0
+            DrawInspectableSpellIcon(sIcon, TARGET.Buff(i), i)
+            iconsDrawn = iconsDrawn + 1
+            -- Check if we've reached the max icons for the row, if so reset counter and new line
+            if iconsDrawn >= maxIconsRow then
+                iconsDrawn = 0 -- Reset counter
             else
-            -- Use SameLine to keep drawing items on the same line, except for when a new line is needed
-            if i < count then
-                ImGui.SameLine()
+                -- Use SameLine to keep drawing items on the same line, except for when a new line is needed
+                if i < count then
+                    ImGui.SameLine()
                 else
-                ImGui.SetCursorPosX(1)
+                    ImGui.SetCursorPosX(1)
+                end
             end
         end
     end
-end
     ImGui.EndGroup()
     ImGui.PopStyleVar()
 end
@@ -137,7 +157,7 @@ function GUI_Target(open)
     --Rounded corners
     ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, 5)
     -- Default window size
-    ImGui.SetNextWindowSize(216,239, ImGuiCond.FirstUseEver)
+    ImGui.SetNextWindowSize(216, 239, ImGuiCond.FirstUseEver)
     local show = false
     open, show = ImGui.Begin("Target", open, winFlag)
     if not show then
@@ -150,11 +170,11 @@ function GUI_Target(open)
         if ME.Combat() then
             ImGui.SetItemAllowOverlap()
             --ImGui.SetCursorPosY(10)
-            ImGui.SetCursorPosX((ImGui.GetContentRegionAvail()/2)-22)
+            ImGui.SetCursorPosX((ImGui.GetContentRegionAvail() / 2) - 22)
             if pulse then
                 COLOR.barColor('pink')
                 pulse = false
-                else
+            else
                 COLOR.barColor('red')
                 pulse = true
             end
@@ -168,10 +188,10 @@ function GUI_Target(open)
         -- Player Information
         ImGui.BeginGroup()
         if ImGui.BeginTable("##playerInfo", 4, tPlayerFlags) then
-            ImGui.TableSetupColumn("##tName", ImGuiTableColumnFlags.NoResize,(ImGui.GetContentRegionAvail()*.5))
-            ImGui.TableSetupColumn("##tVis", ImGuiTableColumnFlags.NoResize,16)
-            ImGui.TableSetupColumn("##tIcons", ImGuiTableColumnFlags.WidthStretch,60)   --ImGui.GetContentRegionAvail()*.25)
-            ImGui.TableSetupColumn("##tLvl", ImGuiTableColumnFlags.NoResize,30)
+            ImGui.TableSetupColumn("##tName", ImGuiTableColumnFlags.NoResize, (ImGui.GetContentRegionAvail() * .5))
+            ImGui.TableSetupColumn("##tVis", ImGuiTableColumnFlags.NoResize, 16)
+            ImGui.TableSetupColumn("##tIcons", ImGuiTableColumnFlags.WidthStretch, 60) --ImGui.GetContentRegionAvail()*.25)
+            ImGui.TableSetupColumn("##tLvl", ImGuiTableColumnFlags.NoResize, 30)
             ImGui.TableNextRow()
             -- Name
             ImGui.SetWindowFontScale(1)
@@ -179,9 +199,9 @@ function GUI_Target(open)
             local meName = ME.DisplayName()
             ImGui.Text(meName)
             local combatState = mq.TLO.Me.CombatState()
-            if combatState=='COMBAT' then
-                ImGui.SameLine(ImGui.GetColumnWidth()-25)
-                DrawStatusIcon(50,'Combat')
+            if combatState == 'COMBAT' then
+                ImGui.SameLine(ImGui.GetColumnWidth() - 25)
+                DrawStatusIcon(50, 'Combat')
             end
             -- Visiblity
             ImGui.TableSetColumnIndex(1)
@@ -190,7 +210,7 @@ function GUI_Target(open)
                     ImGui.PushStyleColor(ImGuiCol.Text, 0, 1, 0, 1)
                     ImGui.Text(Icons.MD_VISIBILITY)
                     ImGui.PopStyleColor()
-                    else
+                else
                     ImGui.PushStyleColor(ImGuiCol.Text, 0.9, 0, 0, 1)
                     ImGui.Text(Icons.MD_VISIBILITY_OFF)
                     ImGui.PopStyleColor()
@@ -203,11 +223,11 @@ function GUI_Target(open)
             ImGui.Text('')
             if TLO.Group.MainTank.ID() == ME.ID() then
                 ImGui.SameLine()
-                DrawStatusIcon(46,'Main Tank')
+                DrawStatusIcon(46, 'Main Tank')
             end
             if TLO.Group.MainAssist.ID() == ME.ID() then
                 ImGui.SameLine()
-                DrawStatusIcon(49,'Main Assist')
+                DrawStatusIcon(49, 'Main Assist')
             end
             ImGui.SameLine()
             --  ImGui.SameLine()
@@ -221,12 +241,12 @@ function GUI_Target(open)
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, 2, 0)
             ImGui.SetWindowFontScale(1)
             ImGui.Text(tostring(ME.Level() or 0))
-           -- ImGui.Text(tostring('125'))
+            -- ImGui.Text(tostring('125'))
             if ImGui.IsItemHovered() then
                 ImGui.BeginTooltip()
                 ImGui.Text(GetInfoToolTip())
                 ImGui.EndTooltip()
-            end            
+            end
             -- ImGui.SameLine()
             -- ImGui.SetWindowFontScale(.75)
             -- ImGui.Text(ME.Class.ShortName())
@@ -238,44 +258,45 @@ function GUI_Target(open)
         -- My Health Bar
         ImGui.SetWindowFontScale(0.75)
         COLOR.barColor('red')
-        ImGui.ProgressBar(((tonumber(ME.PctHPs() or 0))/100), ImGui.GetContentRegionAvail(), 10, '##pctHps')
+        ImGui.ProgressBar(((tonumber(ME.PctHPs() or 0)) / 100), ImGui.GetContentRegionAvail(), 10, '##pctHps')
         ImGui.PopStyleColor()
-        ImGui.SetCursorPosY(ImGui.GetCursorPosY()-15)
-        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ((ImGui.GetWindowWidth()/2)-8))
+        ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 15)
+        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ((ImGui.GetWindowWidth() / 2) - 8))
         ImGui.Text(tostring(ME.PctHPs() or 0))
         --My Mana Bar
-        if (tonumber(ME.MaxMana())>0) then
+        if (tonumber(ME.MaxMana()) > 0) then
             COLOR.barColor('blue')
-            ImGui.ProgressBar(((tonumber(ME.PctMana() or 0))/100), ImGui.GetContentRegionAvail(), 10, '##pctMana')
+            ImGui.ProgressBar(((tonumber(ME.PctMana() or 0)) / 100), ImGui.GetContentRegionAvail(), 10, '##pctMana')
             ImGui.PopStyleColor()
-            ImGui.SetCursorPosY(ImGui.GetCursorPosY()-15)
-            ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ((ImGui.GetWindowWidth()/2)-8))
-            ImGui.Text(tostring(ME.PctMana()or 0))
+            ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 15)
+            ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ((ImGui.GetWindowWidth() / 2) - 8))
+            ImGui.Text(tostring(ME.PctMana() or 0))
         end
         --My Endurance bar
         COLOR.barColor('yellow')
-        ImGui.ProgressBar(((tonumber(ME.PctEndurance() or 0))/100), ImGui.GetContentRegionAvail(), 10, '##pctEndurance')
+        ImGui.ProgressBar(((tonumber(ME.PctEndurance() or 0)) / 100), ImGui.GetContentRegionAvail(), 10, '##pctEndurance')
         ImGui.PopStyleColor()
-        ImGui.SetCursorPosY(ImGui.GetCursorPosY()-15)
-        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ((ImGui.GetWindowWidth()/2)-8))
-        ImGui.Text(tostring(ME.PctEndurance()or 0))
+        ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 15)
+        ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ((ImGui.GetWindowWidth() / 2) - 8))
+        ImGui.Text(tostring(ME.PctEndurance() or 0))
         ImGui.Separator()
         ImGui.EndGroup()
         if ImGui.IsItemHovered() and ImGui.IsMouseReleased(ImGuiMouseButton.Left) then
             mq.cmd('/target  ${Me}')
         end
         --Target Info
-        if (TARGET()~= nil) then
+        if (TARGET() ~= nil) then
             --Target Health Bar
             COLOR.barColor('red')
-            ImGui.ProgressBar(((tonumber(TARGET.PctHPs()or 0))/100), ImGui.GetContentRegionAvail(), 30, '##'..TARGET.PctHPs())
+            ImGui.ProgressBar(((tonumber(TARGET.PctHPs() or 0)) / 100), ImGui.GetContentRegionAvail(), 30,
+                '##' .. TARGET.PctHPs())
             ImGui.PopStyleColor()
             ImGui.SetWindowFontScale(0.9)
-            ImGui.SetCursorPosY(ImGui.GetCursorPosY()-37)
+            ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 37)
             ImGui.SetCursorPosX(9)
             if ImGui.BeginTable("##targetInfoOverlay", 2, tPlayerFlags) then
-                ImGui.TableSetupColumn("##col1", ImGuiTableColumnFlags.NoResize,(ImGui.GetContentRegionAvail()*.5) - 8)
-                ImGui.TableSetupColumn("##col2", ImGuiTableColumnFlags.NoResize,(ImGui.GetContentRegionAvail()*.5) +8) -- Adjust width for distance and Aggro% text
+                ImGui.TableSetupColumn("##col1", ImGuiTableColumnFlags.NoResize, (ImGui.GetContentRegionAvail() * .5) - 8)
+                ImGui.TableSetupColumn("##col2", ImGuiTableColumnFlags.NoResize, (ImGui.GetContentRegionAvail() * .5) + 8) -- Adjust width for distance and Aggro% text
                 -- First Row: Name, con, distance
                 ImGui.TableNextRow()
                 ImGui.TableSetColumnIndex(0) -- Name and CON in the first column
@@ -287,26 +308,27 @@ function GUI_Target(open)
                 local tC = getConLevel(TARGET)
                 COLOR.txtColor(tC)
                 if tC == 'red' then
-                    ImGui.Text('   '..Icons.MD_WARNING)
-                    else
-                    ImGui.Text('   '..Icons.MD_LENS)
+                    ImGui.Text('   ' .. Icons.MD_WARNING)
+                else
+                    ImGui.Text('   ' .. Icons.MD_LENS)
                 end
                 ImGui.PopStyleColor()
-                ImGui.SameLine(ImGui.GetColumnWidth()-35)
+                ImGui.SameLine(ImGui.GetColumnWidth() - 35)
                 COLOR.txtColor('yellow')
-                ImGui.Text(tostring(math.floor(TARGET.Distance() or 0))..'m')
+                ImGui.Text(tostring(math.floor(TARGET.Distance() or 0)) .. 'm')
                 ImGui.PopStyleColor()
                 -- Second Row: Class, Level, and Aggro%
                 ImGui.TableNextRow()
                 ImGui.TableSetColumnIndex(0) -- Class and Level in the first column
-                local tClass = TARGET.Class.ShortName() == 'UNKNOWN CLASS' and Icons.MD_HELP_OUTLINE or TARGET.Class.ShortName()
+                local tClass = TARGET.Class.ShortName() == 'UNKNOWN CLASS' and Icons.MD_HELP_OUTLINE or
+                    TARGET.Class.ShortName()
                 local tLvl = TARGET.Level() or 0
                 local tBodyType = TARGET.Body.Name() or ' '
-                ImGui.Text(tostring(tLvl)..' '..tClass..'\t'..tBodyType)
+                ImGui.Text(tostring(tLvl) .. ' ' .. tClass .. '\t' .. tBodyType)
                 -- Aggro% text in the second column
                 ImGui.TableSetColumnIndex(1)
                 ImGui.SetWindowFontScale(1)
-                ImGui.Text(tostring(TARGET.PctHPs())..'%')
+                ImGui.Text(tostring(TARGET.PctHPs()) .. '%')
                 ImGui.EndTable()
             end
             ImGui.SetWindowFontScale(0.75)
@@ -314,24 +336,25 @@ function GUI_Target(open)
             --Aggro % Bar
             if (TARGET.Aggressive) then
                 COLOR.barColor('purple')
-                ImGui.ProgressBar(((tonumber(TARGET.PctAggro() or 0))/100), ImGui.GetContentRegionAvail(), 10, '##pctAggro')
+                ImGui.ProgressBar(((tonumber(TARGET.PctAggro() or 0)) / 100), ImGui.GetContentRegionAvail(), 10,
+                    '##pctAggro')
                 ImGui.PopStyleColor()
                 --Secondary Aggro Person
-                if (TARGET.SecondaryAggroPlayer()~= nil) then
-                    ImGui.SetCursorPosY(ImGui.GetCursorPosY()-15)
+                if (TARGET.SecondaryAggroPlayer() ~= nil) then
+                    ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 15)
                     ImGui.SetCursorPosX(ImGui.GetCursorPosX() + 5)
                     ImGui.Text(TARGET.SecondaryAggroPlayer.CleanName())
                 end
                 --Aggro % Label middle of bar
-                ImGui.SetCursorPosY(ImGui.GetCursorPosY()-15)
-                ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ((ImGui.GetWindowWidth()/2)-8))
+                ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 15)
+                ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ((ImGui.GetWindowWidth() / 2) - 8))
                 ImGui.Text(TARGET.PctAggro())
-                if (TARGET.SecondaryAggroPlayer()~= nil) then
-                    ImGui.SetCursorPosY(ImGui.GetCursorPosY()-18)
-                    ImGui.SetCursorPosX(ImGui.GetWindowWidth()-40)
+                if (TARGET.SecondaryAggroPlayer() ~= nil) then
+                    ImGui.SetCursorPosY(ImGui.GetCursorPosY() - 18)
+                    ImGui.SetCursorPosX(ImGui.GetWindowWidth() - 40)
                     ImGui.Text(TARGET.SecondaryPctAggro())
                 end
-                else
+            else
                 ImGui.Text('')
             end
             ImGui.Separator()
@@ -345,19 +368,20 @@ function GUI_Target(open)
                 -- End the scrollable region
                 ImGui.Separator()
             end
-            else
+        else
             ImGui.Text('')
         end
         ImGui.PopStyleVar()
         ImGui.Spacing()
         ImGui.End()
-        else
+    else
         ImGui.PopStyleVar()
         ImGui.Spacing()
         ImGui.End()
     end
     return open
 end
+
 local openGUI = true
 ImGui.Register('GUI_Target', function()
     openGUI = GUI_Target(openGUI)
@@ -366,9 +390,9 @@ local function MainLoop()
     while true do
         mq.delay(1000)
         if ME.Zoning() then
-                ShowGUI = false
-            else
-                ShowGUI = true
+            ShowGUI = false
+        else
+            ShowGUI = true
         end
         if not openGUI then
             openGUI = ShowGUI
@@ -376,5 +400,5 @@ local function MainLoop()
         end
     end
 end
-print('\aw'..mq.TLO.Time()..' [\ayPlayer Targ\aw] ::\ax '..'\a-t Version \aw::\ax \ay'..ver..'\ax\at Loaded\ax')
+print('\aw' .. mq.TLO.Time() .. ' [\ayPlayer Targ\aw] ::\ax ' .. '\a-t Version \aw::\ax \ay' .. ver .. '\ax\at Loaded\ax')
 MainLoop()


### PR DESCRIPTION
…rently this border is hard coded in MQ code to be gray, pending a change by brainiac to be pushed to the main branch which will allow it to be modified by ImStyleCol.Border

Added a RectFilled over buffs with 18 or less seconds remaining.  The alpha of this rectangle is modified to increase, or decrease (alternating) each time the targetBuffs function is ran.  This will give buffs with a low remaining duration a pulsing effect.

Modified ItemSpacing of the buffs to be 2x2 instead of 0x0 to prevent overlap of the borders on icons.

Modified maxIconRows to take the extra width from the ItemSpacing into account, as well as added a math.floor() around the calculation to always cause the number of icons per row to round down and not cause buffs to be cut off or drawn where the user is unable to see them.